### PR TITLE
Use mbr module's byteOffset and byteSize methods

### DIFF
--- a/build/partition.js
+++ b/build/partition.js
@@ -33,40 +33,6 @@ exports.getPartition = function(record, number) {
 
 
 /**
- * @summary Get a partition offset
- * @protected
- * @function
- *
- * @param {Object} partition - partition
- * @returns {Number} partition offset
- *
- * @example
- * offset = partition.getPartitionOffset(myPartition)
- */
-
-exports.getPartitionOffset = function(partition) {
-  return partition.firstLBA * SECTOR_SIZE;
-};
-
-
-/**
- * @summary Get the partition size in bytes
- * @protected
- * @function
- *
- * @param {Object} partition - partition
- * @returns {Number} partition size
- *
- * @example
- * size = partition.getPartitionSize(myPartition)
- */
-
-exports.getPartitionSize = function(partition) {
-  return partition.sectors * SECTOR_SIZE;
-};
-
-
-/**
  * @summary Get a partition object from a definition
  * @protected
  * @function
@@ -90,7 +56,7 @@ exports.getPartitionFromDefinition = function(image, definition) {
     if ((definition.logical == null) || definition.logical === 0) {
       return primaryPartition;
     }
-    primaryPartitionOffset = exports.getPartitionOffset(primaryPartition);
+    primaryPartitionOffset = primaryPartition.byteOffset();
     return bootRecord.getExtended(image, primaryPartitionOffset).then(function(ebr) {
       var logicalPartition;
       if (ebr == null) {

--- a/build/partitioninfo.js
+++ b/build/partitioninfo.js
@@ -34,8 +34,8 @@ partition = require('./partition');
 exports.get = function(image, definition) {
   return partition.getPartitionFromDefinition(image, definition).then(function(parsedPartition) {
     return Promise.props({
-      offset: partition.getPartitionOffset(parsedPartition),
-      size: partition.getPartitionSize(parsedPartition)
+      offset: parsedPartition.byteOffset(),
+      size: parsedPartition.byteSize()
     });
   });
 };

--- a/lib/partition.coffee
+++ b/lib/partition.coffee
@@ -25,34 +25,6 @@ exports.getPartition = (record, number) ->
 	return result
 
 ###*
-# @summary Get a partition offset
-# @protected
-# @function
-#
-# @param {Object} partition - partition
-# @returns {Number} partition offset
-#
-# @example
-# offset = partition.getPartitionOffset(myPartition)
-###
-exports.getPartitionOffset = (partition) ->
-	return partition.firstLBA * SECTOR_SIZE
-
-###*
-# @summary Get the partition size in bytes
-# @protected
-# @function
-#
-# @param {Object} partition - partition
-# @returns {Number} partition size
-#
-# @example
-# size = partition.getPartitionSize(myPartition)
-###
-exports.getPartitionSize = (partition) ->
-	return partition.sectors * SECTOR_SIZE
-
-###*
 # @summary Get a partition object from a definition
 # @protected
 # @function
@@ -75,7 +47,7 @@ exports.getPartitionFromDefinition = (image, definition) ->
 		if not definition.logical? or definition.logical is 0
 			return primaryPartition
 
-		primaryPartitionOffset = exports.getPartitionOffset(primaryPartition)
+		primaryPartitionOffset = primaryPartition.byteOffset()
 
 		bootRecord.getExtended(image, primaryPartitionOffset).then (ebr) ->
 

--- a/lib/partitioninfo.coffee
+++ b/lib/partitioninfo.coffee
@@ -28,5 +28,5 @@ partition = require('./partition')
 exports.get = (image, definition) ->
 	partition.getPartitionFromDefinition(image, definition).then (parsedPartition) ->
 		return Promise.props
-			offset: partition.getPartitionOffset(parsedPartition)
-			size: partition.getPartitionSize(parsedPartition)
+			offset: parsedPartition.byteOffset()
+			size: parsedPartition.byteSize()

--- a/tests/partitioninfo.spec.coffee
+++ b/tests/partitioninfo.spec.coffee
@@ -1,7 +1,11 @@
 m = require('mochainon')
 Promise = require('bluebird')
+fs = require 'fs'
 partitioninfo = require('../lib/partitioninfo')
 partition = require('../lib/partition')
+bootRecord = require('../lib/boot-record')
+
+rpiMBR = fs.readFileSync('./tests/mbr/rpi.data')
 
 describe 'Partitioninfo:', ->
 
@@ -10,18 +14,14 @@ describe 'Partitioninfo:', ->
 		describe 'given a valid partition', ->
 
 			beforeEach ->
-				@getPartitionFromDefinitionStub = m.sinon.stub(partition, 'getPartitionFromDefinition')
-				@getPartitionFromDefinitionStub.returns Promise.resolve
-					status: 128
-					type: 12
-					sectors: 40960
-					firstLBA: 8192
+				@bootRecordReadStub = m.sinon.stub(bootRecord, 'read')
+				@bootRecordReadStub.returns(Promise.resolve(rpiMBR))
 
 			afterEach ->
-				@getPartitionFromDefinitionStub.restore()
+				@bootRecordReadStub.restore()
 
 			it 'should return an information object', ->
-				promise = partitioninfo.get('foo/bar.img')
+				promise = partitioninfo.get('mbr/rpi', primary: 1)
 				m.chai.expect(promise).to.eventually.become
 					offset: 4194304
 					size: 20971520


### PR DESCRIPTION
I changed .get method from the main module to use the byteOffset and byteSize methods from mbr module instead of our re-implementation of them (they are used for geting offset and size in bytes instead of sectors).

I also fixed tests of get function, to correctly pass a partition definition, since the function does not work without them. I found the bug in tests when I switched them from stubbing getPartitionFromDefinition to stubbing the lower-level bootRecord.read function.

In general I would suggest stubbing as low level functions as possible, to catch errors like this. I would even say it would be better to stub the filesystem rather than anything else.
