### PR TITLE
When reading MBR open images only for reading.

### DIFF
--- a/build/boot-record.js
+++ b/build/boot-record.js
@@ -1,4 +1,4 @@
-var BOOT_RECORD_SIZE, MasterBootRecord, Promise, fs, getMaster;
+var BOOT_RECORD_SIZE, MasterBootRecord, Promise, fs;
 
 Promise = require('bluebird');
 
@@ -31,7 +31,7 @@ exports.read = function(image, position) {
     position = 0;
   }
   result = new Buffer(BOOT_RECORD_SIZE);
-  return fs.openAsync(image, 'r+').then(function(fd) {
+  return fs.openAsync(image, 'r').then(function(fd) {
     return fs.readAsync(fd, result, 0, BOOT_RECORD_SIZE, position)["return"](fd);
   }).then(function(fd) {
     return fs.closeAsync(fd);
@@ -77,10 +77,10 @@ exports.parse = function(mbrBuffer) {
 
 exports.getExtended = function(image, position) {
   return exports.read(image, position).then(function(buffer) {
-    var result;
+    var error, result;
     try {
       result = exports.parse(buffer);
-    } catch (_error) {
+    } catch (error) {
       return;
     }
     return result;
@@ -101,6 +101,6 @@ exports.getExtended = function(image, position) {
  *		console.log(mbr)
  */
 
-exports.getMaster = getMaster = function(image) {
+exports.getMaster = function(image) {
   return exports.read(image, 0).then(exports.parse);
 };

--- a/build/partitioninfo.js
+++ b/build/partitioninfo.js
@@ -1,4 +1,4 @@
-var MBR, Promise, bootRecord, getPartitions, partition, _;
+var MBR, Promise, _, bootRecord, getPartitions, partition;
 
 Promise = require('bluebird');
 

--- a/lib/boot-record.coffee
+++ b/lib/boot-record.coffee
@@ -22,7 +22,7 @@ BOOT_RECORD_SIZE = 512
 exports.read = (image, position = 0) ->
 	result = new Buffer(BOOT_RECORD_SIZE)
 
-	fs.openAsync(image, 'r+').then (fd) ->
+	fs.openAsync(image, 'r').then (fd) ->
 		return fs.readAsync(fd, result, 0, BOOT_RECORD_SIZE, position).return(fd)
 	.then (fd) ->
 		return fs.closeAsync(fd)


### PR DESCRIPTION
r+ opens the file for reading and writing, but we do not need
writting permissions.

This actually causes problems on our infastructure as we are using
overlayfs, and it copies the images when they are opened for writing.
